### PR TITLE
Support top level hook props in JSX renderer

### DIFF
--- a/src/__tests__/fixtures/transform-prop-fixture.js
+++ b/src/__tests__/fixtures/transform-prop-fixture.js
@@ -8,7 +8,7 @@ import { RotomElement, register } from "../../rotom.jsx.js"
  */
 export function createPropTransformFixture(
   id,
-  { className, ariaLabel, dataset, handler } = {}
+  { className, ariaLabel, dataset, handler, hookDestroy } = {}
 ) {
   class TestElement extends RotomElement {
     render() {
@@ -18,6 +18,7 @@ export function createPropTransformFixture(
           aria-label={ariaLabel}
           data-baz-buz={dataset}
           on-click={handler}
+          hook-destroy={hookDestroy}
         >
           Prop test
         </div>

--- a/src/__tests__/rotom.spec.js
+++ b/src/__tests__/rotom.spec.js
@@ -292,7 +292,7 @@ describe("RotomElement", () => {
   })
 
   describe("jsx prop transformers", () => {
-    it("applies className prop to class attribute", () => {
+    it("applies className prop to data.props.className", () => {
       // Given
       const tagName = "class-transform"
       const className = "foo"
@@ -302,7 +302,7 @@ describe("RotomElement", () => {
       expect(node.getAttribute("class")).toEqual(className)
     })
 
-    it("applies aria prop to attribute", () => {
+    it("applies aria prop to data.attrs", () => {
       // Given
       const tagName = "aria-transform"
       const ariaLabel = "foo"
@@ -312,7 +312,7 @@ describe("RotomElement", () => {
       expect(node.getAttribute("aria-label")).toEqual(ariaLabel)
     })
 
-    it("applies dataset prop to attribute", () => {
+    it("applies data prop to data.dataset", () => {
       // Given
       const tagName = "dataset-transform"
       const dataset = "foo"
@@ -322,7 +322,7 @@ describe("RotomElement", () => {
       expect(node.getAttribute("data-baz-buz")).toEqual(dataset)
     })
 
-    it("applies event handler prop", () => {
+    it("applies event handler data.on", () => {
       // Given
       let num = 0
       const handler = () => (num += 1)
@@ -333,6 +333,19 @@ describe("RotomElement", () => {
       document.body.addEventListener("click", assert)
       getElement(tagName).shadowRoot.firstElementChild.click()
       document.body.removeEventListener("click", assert)
+    })
+
+    it("applies hook prop to data.hook", () => {
+      // Given
+      let num = 0
+      const hookDestroy = () => (num += 1)
+      const tagName = "hook-transform"
+      createPropTransformFixture(tagName, { hookDestroy })
+      // When
+      const fixture = getElement(tagName)
+      fixture.parentNode.removeChild(fixture)
+      // Then
+      expect(num).toEqual(1)
     })
   })
 })

--- a/src/renderers/jsx/transformers/transform-jsx-props.js
+++ b/src/renderers/jsx/transformers/transform-jsx-props.js
@@ -51,5 +51,17 @@ export function transformJsxProps(vnode) {
     delete node.data[key]
   })
 
+  setPropToModule(vnode, /^hook-/, ({ key, value, node }) => {
+    const abbrevName = key.split("-")[1]
+
+    if (node.data.hook) {
+      node.data.hook[abbrevName] = value
+    } else {
+      node.data.hook = { [abbrevName]: value }
+    }
+
+    delete node.data[key]
+  })
+
   return vnode
 }

--- a/src/renderers/jsx/transformers/transform-jsx-props.js
+++ b/src/renderers/jsx/transformers/transform-jsx-props.js
@@ -7,6 +7,7 @@ import { setPropToModule } from "./set-prop-to-module"
  * @returns {Object} vnode
  */
 export function transformJsxProps(vnode) {
+  // e.g., aria-label -> vnode.data.attrs['aria-label']
   setPropToModule(vnode, /^aria-/, ({ key, value, node }) => {
     // debugger
     if (node.data.attrs) {
@@ -17,6 +18,7 @@ export function transformJsxProps(vnode) {
     delete node.data[key]
   })
 
+  // e.g., data-foo-bar -> vnode.data.dataset.fooBar
   setPropToModule(vnode, /^data-/, ({ key, value, node }) => {
     const abbrevName = kebabToCamel(key.slice(5))
 
@@ -29,6 +31,7 @@ export function transformJsxProps(vnode) {
     delete node.data[key]
   })
 
+  // e.g., className -> vnode.data.props.className
   setPropToModule(vnode, /^className$/, ({ value, node }) => {
     if (node.data.props) {
       node.data.props.className = value
@@ -39,6 +42,7 @@ export function transformJsxProps(vnode) {
     delete node.data.className
   })
 
+  // e.g., on-click -> vnode.data.on.click
   setPropToModule(vnode, /^on-/, ({ key, value, node }) => {
     const abbrevName = key.split("-")[1]
 
@@ -51,6 +55,7 @@ export function transformJsxProps(vnode) {
     delete node.data[key]
   })
 
+  // e.g., hook-update -> vnode.data.hook.update
   setPropToModule(vnode, /^hook-/, ({ key, value, node }) => {
     const abbrevName = key.split("-")[1]
 

--- a/test/jsx/fixtures/render-schedule-test.js
+++ b/test/jsx/fixtures/render-schedule-test.js
@@ -54,6 +54,8 @@ export class RenderScheduleTest extends RotomElement {
           It should have one render per button press, despite having multiple
           property updates.
           <div
+            // eslint-disable-next-line no-console
+            hook-insert={({ elm }) => console.log("hook-insert mounted:", elm)}
             data-foo-bar="baz"
             aria-hidden="true"
             aria-labelledby="#0"


### PR DESCRIPTION
Enables writing Snabbdom hooks as e.g. `hook-destroy={() => {}}` instead of `hook={{ destroy: () => {} }}`.

﻿- feat: adds jsx prop transform for snabbdom hooks
﻿- test: adds tests for hook jsx prop transformer
